### PR TITLE
Add adios io scheduler

### DIFF
--- a/kernel-cachyos/cachySettings.nix
+++ b/kernel-cachyos/cachySettings.nix
@@ -4,6 +4,9 @@ with lib.kernel;
 {
   common = {
     CACHY = yes;
+
+    # https://wiki.cachyos.org/configuration/general_system_tweaks/#adios-io-scheduler
+    MQ_IOSCHED_ADIOS = yes;
   };
 
   cpusched = rec {


### PR DESCRIPTION
Fancy new toy. [CachyOS documentation](https://wiki.cachyos.org/configuration/general_system_tweaks/#adios-io-scheduler).

This option merely enables the compilation of the module. `IOSCHED_DEFAULT_ADIOS` is not touched. The module can be enabled via sysfs or udev rules, see documentation above.

Enabled by default in upstream config, see https://github.com/CachyOS/linux-cachyos/blob/b68aded713a580df028543faea77c4ca5ec1226b/linux-cachyos/config#L1170

Not sure if it is the correct place to put the config. Suggestions are appreciated.