### PR TITLE
fix: fix mkCachyKernel output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,14 +87,20 @@
           };
 
           mkCachyKernel =
-            { buildLinux, pkgs, ... } @ args:
+            { buildLinux, pkgs, ... }@args:
             (import ./kernel-cachyos/mkCachyKernel.nix) {
-              inherit inputs lib buildLinux args;
+              inherit
+                inputs
+                lib
+                buildLinux
+                args
+                ;
               inherit (pkgs)
                 stdenv
-		callPackage
+                callPackage
                 kernelPatches
                 applyPatches
+                impureUseNativeOptimizations
                 ;
             };
 


### PR DESCRIPTION
Because of the way mkCachyKernel is exposed, we need to explicitely inherit the inputs. This makes sure we inherit impureUseNativeOptimizations properly.