### PR TITLE
Enable CONFIG_RUST=y in common settings

### DIFF
--- a/kernel-cachyos/cachySettings.nix
+++ b/kernel-cachyos/cachySettings.nix
@@ -4,6 +4,7 @@ with lib.kernel;
 {
   common = {
     CACHY = yes;
+    RUST = yes;
 
     # https://wiki.cachyos.org/configuration/general_system_tweaks/#adios-io-scheduler
     MQ_IOSCHED_ADIOS = yes;


### PR DESCRIPTION
Upstream CachyOS already has `CONFIG_RUST=y` in their kernel config, but the nix packages don't set it. This means the kernel gets built without Rust support even though `withRust = true` is exposed and rustc/bindgen are in `moduleBuildDependencies`.

The practical effect is that `make modules_prepare` never generates the Rust sysroot (`rust/` dir with libcore, liballoc, libkernel) or `scripts/target.json`, so out-of-tree Rust kernel modules can't be compiled against these kernels.

This one-liner in `cachySettings.common` fixes it for all variants.

Closes #37