### PR TITLE
feat: Change default scheduler to eevdf

### DIFF
--- a/kernel-cachyos/mkCachyKernel.nix
+++ b/kernel-cachyos/mkCachyKernel.nix
@@ -31,7 +31,7 @@ lib.makeOverridable (
     # CachyOS fine tuning settings, see ./cachySettings.nix for corresponding options
     # Default value sourced from https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/PKGBUILD
     # Set to null or false to disable
-    cpusched ? "bore",
+    cpusched ? "eevdf",
     kcfi ? false,
     hzTicks ? "1000",
     performanceGovernor ? false,


### PR DESCRIPTION
Upstream CachyOS switched their scheduler to eevdf. I doesn't seem like there was an official announcement, but there are a few mentions of it:
https://github.com/CachyOS/linux-cachyos/commit/ff5ccc4fa26d5272d929fb9c1838593a6347ca10
https://github.com/CachyOS/linux-cachyos/commit/fce577750ec855408ecdf31cf1bfed087db36b03

And the commit disabling bore from 5 months ago https://github.com/CachyOS/linux-cachyos/commit/709f0cf3d9be2d3007d6a0d807d80eb304a203ad