### PR TITLE
Add hardened kernel source

### DIFF
--- a/kernel-cachyos/default.nix
+++ b/kernel-cachyos/default.nix
@@ -204,13 +204,13 @@ builtins.listToAttrs (
     })
     (mkCachyKernel {
       pname = "linux-cachyos-hardened";
-      inherit (linuxSources.latest) version src;
+      inherit (linuxSources.hardened) version src;
       configVariant = "linux-cachyos-hardened";
       hardened = true;
     })
     (mkCachyKernel {
       pname = "linux-cachyos-hardened-lto";
-      inherit (linuxSources.latest) version src;
+      inherit (linuxSources.hardened) version src;
       configVariant = "linux-cachyos-hardened";
       hardened = true;
       lto = "thin";

--- a/kernel-cachyos/update.py
+++ b/kernel-cachyos/update.py
@@ -67,7 +67,7 @@ def run_nix_prefetch_url(url: str) -> str:
 
 if __name__ == "__main__":
     versions = {}
-    for variant in ["latest", "lts", "rc"]:
+    for variant in ["latest", "lts", "rc", "hardened"]:
         print(f"{variant=}")
         srctag = get_srctag(variant)
         real_version = "-".join(srctag.split("-")[1:-1])

--- a/kernel-cachyos/version.json
+++ b/kernel-cachyos/version.json
@@ -13,5 +13,10 @@
     "version": "7.0-rc3",
     "url": "https://github.com/CachyOS/linux/releases/download/cachyos-7.0-rc3-1/cachyos-7.0-rc3-1.tar.gz",
     "hash": "sha256-+oWnfrNyTioD00QqvV5mbDoz/h/bjIVe0f+uWekjnFI="
+  },
+  "hardened": {
+    "version": "6.18.17",
+    "url": "https://github.com/CachyOS/linux/releases/download/cachyos-6.18.17-1/cachyos-6.18.17-1.tar.gz",
+    "hash": "sha256-qpTxo8Q+4Bn3vXl7VHOc4vS4WswrlqNDCr9TQZHdC2Y="
   }
 }


### PR DESCRIPTION
The hardened patchset is a minimal series of tailored patches maintained at https://github.com/anthraxx/linux-hardened. It takes a while to test everything, so it usually lags behind other kernel releases (e.g. only was updated from 6.17 to 6.18 in the cachy kernels a few days ago), so pinning the hardened kernels to the latest cachy kernel version will often mean that the hardened kernels fail to build.

Thus, I added an extra source for the new hardened patchset, so that they will always build, and we don't have to worry about them. We could also just pin it to the `lts` version instead of adding this new source to track. This avoids the problem cachyos has with it's hardened version where it gets stuck on an unmaintained kernel version while the new patches wait to be released (e.g. until recently they were on 6.17, which was eol and getting no updates for a few months). What are you thoughts?