### PR TITLE
Fix cpusched options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,7 @@ The following arguments can be passed to `mkCachyKernel`:
 
 **CachyOS Fine Tuning Settings:**
 
-- **`cpusched`**: CPU scheduler. Options: `"bore"` (default), `"bmq"`, or `null` to disable.
-- **`kcfi`**: Enable Kernel Control Flow Integrity. Default: `false`.
+- **`cpusched`**: CPU scheduler. Options: `"eevdf"` (default), `"bore"`, `"bmq"`, `"hardened"`, `"rt"`, `"rt-bore"` or `null` to disable.- **`kcfi`**: Enable Kernel Control Flow Integrity. Default: `false`.
 - **`hzTicks`**: Timer frequency. Options: `"1000"` (default), `"250"`, `"300"`, `"500"`, `"750"`, or `null` to disable.
 - **`performanceGovernor`**: Enable performance governor. Default: `false`.
 - **`tickrate`**: Tick rate. Options: `"full"` (default), `"periodic"`, `"idle"`, `"nohz_full"`, or `null` to disable.


### PR DESCRIPTION
Default CPU scheduler isn't `bore` but `eevdf` according to both https://github.com/xddxdd/nix-cachyos-kernel/blob/master/kernel-cachyos/mkCachyKernel.nix and https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/PKGBUILD
Also mention other cpusched available values from PKGBUILD