### PR TITLE
Fix cpusched options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The following arguments can be passed to `mkCachyKernel`:
 
 **CachyOS Fine Tuning Settings:**
 
-- **`cpusched`**: CPU scheduler. Options: `"bore"` (default), `"bmq"`, or `null` to disable.
+- **`cpusched`**: CPU scheduler. Options: `"eevdf"` (default), `"bore"`, `"bmq"`, `"hardened"`, `"rt"`, `"rt-bore"` or `null` to disable.
 - **`kcfi`**: Enable Kernel Control Flow Integrity. Default: `false`.
 - **`hzTicks`**: Timer frequency. Options: `"1000"` (default), `"250"`, `"300"`, `"500"`, `"750"`, or `null` to disable.
 - **`performanceGovernor`**: Enable performance governor. Default: `false`.


### PR DESCRIPTION
Default CPU scheduler isn't `bore` but `eevdf` according to both https://github.com/xddxdd/nix-cachyos-kernel/blob/master/kernel-cachyos/mkCachyKernel.nix and https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/PKGBUILD.  
Might be a temporary choice by CachyOS maintainers to revert to eevdf, so we should keep an eye on it.  
Also mention other cpusched available values from PKGBUILD