### PR TITLE
Update update.py to correctly extract src version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cachyos-kernel": {
       "flake": false,
       "locked": {
-        "lastModified": 1775946783,
-        "narHash": "sha256-r4crlTkb2+JDfI92JvYZvYMN9bS8zCmpSPGq/U04hDs=",
+        "lastModified": 1776183001,
+        "narHash": "sha256-lvLKB5dTqjO1S/YonS9ZyWemEjO6QXtN4D76rYEYy4s=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "48b84486b873e8c2c001c0e7c7702dd6034b6cd2",
+        "rev": "4224303b6d7a50dd1cc3ffa78864050cc9536eec",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1776057062,
-        "narHash": "sha256-1s4YryleUClOh2GdhtIt3mjcXO3/czttvxbO8sPYLQU=",
+        "lastModified": 1776181525,
+        "narHash": "sha256-g07GhYlAOH0agNE8dIOT33vZ0eviF/HY5xgAQRwLytk=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "a0a4cfc513bec1b917aabdea4f30cd8fa2d83e8e",
+        "rev": "fcd21edaf0ff9b69f9d32ea8590002d6acd1c503",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776030597,
-        "narHash": "sha256-H2CYM/RmVqCo1iud5BhPp8Pim2d1ESGt2FDHjbmju8A=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c88e63f4caf12c731f61ce71f300680ce73c180e",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/kernel-cachyos/update.py
+++ b/kernel-cachyos/update.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 
-def get_srctag(variant: str = "latest") -> str:
+def get_srcname(variant: str = "latest") -> str:
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as dir:
         subprocess.run(
             ["nix", "build", ".#cachyos-kernel-input-path", "-o", f"{dir}/result"],
@@ -18,7 +18,7 @@ def get_srctag(variant: str = "latest") -> str:
         with open(f"{dir}/result/{pkgbuild_path}/PKGBUILD") as f:
             pkgbuild = f.read()
 
-        script = pkgbuild + "\necho $_srctag"
+        script = pkgbuild + "\necho $_srcname"
         result = subprocess.run(
             ["bash"],
             input=script,
@@ -69,11 +69,11 @@ if __name__ == "__main__":
     versions = {}
     for variant in ["latest", "lts", "rc", "hardened"]:
         print(f"{variant=}")
-        srctag = get_srctag(variant)
-        real_version = "-".join(srctag.split("-")[1:-1])
-        print(f"{srctag=} {real_version=}")
+        srcname = get_srcname(variant)
+        real_version = "-".join(srcname.split("-")[1:-1])
+        print(f"{srcname=} {real_version=}")
 
-        url = f"https://github.com/CachyOS/linux/releases/download/{srctag}/{srctag}.tar.gz"
+        url = f"https://github.com/CachyOS/linux/releases/download/{srcname}/{srcname}.tar.gz"
         print(f"{url=}")
         hash = run_nix_prefetch_url(url)
         hash = nix_sha256_to_sri(hash)

--- a/kernel-cachyos/version.json
+++ b/kernel-cachyos/version.json
@@ -1,8 +1,8 @@
 {
   "latest": {
-    "version": "6.19.12",
-    "url": "https://github.com/CachyOS/linux/releases/download/cachyos-6.19.12-2/cachyos-6.19.12-2.tar.gz",
-    "hash": "sha256-0aVvSjC/pb2Xz1rQNELYTSwXMlAJVMiUj43VrA42EqQ="
+    "version": "7.0.0",
+    "url": "https://github.com/CachyOS/linux/releases/download/cachyos-7.0.0-2/cachyos-7.0.0-2.tar.gz",
+    "hash": "sha256-2DXjHcxmZb5D2oSE0mfiLjP5+LWeTyiSzpQXBecoMYo="
   },
   "lts": {
     "version": "6.18.22",


### PR DESCRIPTION
They updated their PKGBUILDs upstream to no longer have a `$_srctag` variable defined, only `$_srcname`, so change the update script to use that.