### PR TITLE
linux-cachyos-bmq: fix build

### DIFF
--- a/kernel-cachyos/cachySettings.nix
+++ b/kernel-cachyos/cachySettings.nix
@@ -16,6 +16,7 @@ with lib.kernel;
     bmq = {
       SCHED_ALT = yes;
       SCHED_BMQ = yes;
+      SCHED_POC_SELECTOR = no;
     };
     eevdf = { };
     rt = {


### PR DESCRIPTION
Upstream has some funky interactions between patches. See https://github.com/CachyOS/kernel-patches/issues/152 for details. But overall, it means we cannot both set `SCHED_ALT` and `SCHED_POC_SELECTOR`, so disable the poc selector for now until upstream allows both to coexist.