### PR TITLE
Revert "linux-cachyos-bmq: fix build"

### DIFF
--- a/kernel-cachyos/cachySettings.nix
+++ b/kernel-cachyos/cachySettings.nix
@@ -16,7 +16,6 @@ with lib.kernel;
     bmq = {
       SCHED_ALT = yes;
       SCHED_BMQ = yes;
-      SCHED_POC_SELECTOR = no;
     };
     eevdf = { };
     rt = {


### PR DESCRIPTION
Reverts xddxdd/nix-cachyos-kernel#63

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line kernel config change limited to the BMQ scheduler variant; low blast radius, with main risk being altered build/selection behavior for that option.
> 
> **Overview**
> Removes the `SCHED_POC_SELECTOR = no;` override from the `cpusched.bmq` kernel config in `kernel-cachyos/cachySettings.nix`, reverting to the kernel’s default handling for that option when building the BMQ scheduler variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bad25cc612dc263c98b8a082cef323e4e129c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->