### PR TITLE
Restore x86_64-v2 variants in kernel-cachyos/default.nix (eval-only, no garnix build cost)

### DIFF
--- a/kernel-cachyos/default.nix
+++ b/kernel-cachyos/default.nix
@@ -17,11 +17,17 @@ let
 in
 builtins.listToAttrs (
   builtins.map (v: lib.nameValuePair v.pname v) [
-    # Latest kernel, provide all LTO and v3/v4/zen4 arch variants
+    # Latest kernel, provide all LTO and v2/v3/v4/zen4 arch variants
     (mkCachyKernel {
       pname = "linux-cachyos-latest";
       inherit (linuxSources.latest) version src;
       configVariant = "linux-cachyos";
+    })
+    (mkCachyKernel {
+      pname = "linux-cachyos-latest-x86_64-v2";
+      inherit (linuxSources.latest) version src;
+      configVariant = "linux-cachyos";
+      processorOpt = "x86_64-v2";
     })
     (mkCachyKernel {
       pname = "linux-cachyos-latest-x86_64-v3";
@@ -46,6 +52,13 @@ builtins.listToAttrs (
       inherit (linuxSources.latest) version src;
       configVariant = "linux-cachyos";
       lto = "thin";
+    })
+    (mkCachyKernel {
+      pname = "linux-cachyos-latest-lto-x86_64-v2";
+      inherit (linuxSources.latest) version src;
+      configVariant = "linux-cachyos";
+      lto = "thin";
+      processorOpt = "x86_64-v2";
     })
     (mkCachyKernel {
       pname = "linux-cachyos-latest-lto-x86_64-v3";
@@ -76,6 +89,12 @@ builtins.listToAttrs (
       configVariant = "linux-cachyos-lts";
     })
     (mkCachyKernel {
+      pname = "linux-cachyos-lts-x86_64-v2";
+      inherit (linuxSources.lts) version src;
+      configVariant = "linux-cachyos-lts";
+      processorOpt = "x86_64-v2";
+    })
+    (mkCachyKernel {
       pname = "linux-cachyos-lts-x86_64-v3";
       inherit (linuxSources.lts) version src;
       configVariant = "linux-cachyos-lts";
@@ -98,6 +117,13 @@ builtins.listToAttrs (
       inherit (linuxSources.lts) version src;
       configVariant = "linux-cachyos-lts";
       lto = "thin";
+    })
+    (mkCachyKernel {
+      pname = "linux-cachyos-lts-lto-x86_64-v2";
+      inherit (linuxSources.lts) version src;
+      configVariant = "linux-cachyos-lts";
+      lto = "thin";
+      processorOpt = "x86_64-v2";
     })
     (mkCachyKernel {
       pname = "linux-cachyos-lts-lto-x86_64-v3";


### PR DESCRIPTION
## Summary

Restores the four `x86_64-v2` variant entries that PR #50 removed from `kernel-cachyos/default.nix`, **without adding build cost on garnix**.

## Rationale

PR #50's stated motivation was build compute — adding BORE × v3/v4/zen4 already takes ~12h on the home server, and the v2 builds had to give. Completely understand the constraint.

However, removing the *attrs* from `default.nix` is a strictly stronger step than removing the *builds*. The current `garnix.yaml` `builds.include` list contains only the four baseline variants:

```yaml
builds:
  include:
    - packages.x86_64-linux.linux-cachyos-latest
    - packages.x86_64-linux.linux-cachyos-latest-lto
    - packages.x86_64-linux.linux-cachyos-lts
    - packages.x86_64-linux.linux-cachyos-lts-lto
```

Even before PR #50, the v3/v4/zen4 variants weren't auto-built by garnix (they're served from your own attic cache, which is configured separately from this repo). So restoring the v2 entries to `default.nix` **doesn't change what garnix builds** — v2 stays excluded from garnix builds by virtue of not being in the include list. Eval cost of an extra four `mkCachyKernel` calls per CI run is in the milliseconds.

## What this changes

Re-adds four entries to `kernel-cachyos/default.nix`:

- `linux-cachyos-latest-x86_64-v2`
- `linux-cachyos-latest-lto-x86_64-v2`
- `linux-cachyos-lts-x86_64-v2`
- `linux-cachyos-lts-lto-x86_64-v2`

Each calls `mkCachyKernel` with `processorOpt = "x86_64-v2"`. This is a partial revert of PR #50's v2 deletions; PR #50's BORE × v3/v4/zen4 additions are kept untouched.

The supporting infrastructure was always intact — `mkCachyKernel.nix` still accepts `processorOpt = "x86_64-v2"`, `cachySettings.nix` still has the full `x86_64-v2` config block, and CachyOS upstream `linux-cachyos`/`linux-cachyos-lts` PKGBUILDs still build v2.

## What this does NOT change

- `garnix.yaml` — unchanged; v2 stays out of garnix's include list
- `mkCachyKernel.nix`, `helpers.nix`, `cachySettings.nix` — unchanged
- Your attic cache strategy — outside this repo's scope

## Why this helps downstream

I maintain a NixOS flake that targets a 2012 MacBook Pro 9,2 (Ivy Bridge, v2-only). After PR #50 I had to vendor a copy of `mkCachyKernel` into my own flake to rebuild the v2 variants locally (`processorOpt = "x86_64-v2"` still works, just not exposed). This PR would let me drop that vendored copy and consume `pkgs.cachyosKernels.linux-cachyos-latest-lto-x86_64-v2` directly. Other v2 users likely have similar workarounds.

## Alternatives considered

If you'd prefer to keep these isolated from the default `legacyPackages` set, happy to refactor into a separate `legacyPackages.${system}.extraVariants` attribute (or similar opt-in) so the default set stays trim. Let me know your preference.

Thanks for maintaining nix-cachyos-kernel.
