### PR TITLE
Move loadPackages outside of the flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,36 +36,6 @@
         lib,
         ...
       }:
-      let
-        loadPackages =
-          pkgs:
-          let
-            load =
-              path:
-              lib.removeAttrs
-                (pkgs.callPackage path {
-                  inherit inputs;
-                })
-                [
-                  "override"
-                  "overrideDerivation"
-                ];
-            kernels = load ./kernel-cachyos;
-            packages = load ./kernel-cachyos/packages.nix;
-          in
-          kernels
-          // packages
-          // {
-            zfs-cachyos = packages.linuxPackages-cachyos-latest.zfs_cachyos;
-            zfs-cachyos-lto = packages.linuxPackages-cachyos-latest-lto.zfs_cachyos;
-            zfs-cachyos-lts = packages.linuxPackages-cachyos-lts.zfs_cachyos;
-            zfs-cachyos-lts-lto = packages.linuxPackages-cachyos-lts-lto.zfs_cachyos;
-            zfs-cachyos-hardened = packages.linuxPackages-cachyos-hardened.zfs_cachyos;
-            zfs-cachyos-hardened-lto = packages.linuxPackages-cachyos-hardened-lto.zfs_cachyos;
-            zfs-cachyos-rc = packages.linuxPackages-cachyos-rc.zfs_cachyos;
-            zfs-cachyos-rc-lto = packages.linuxPackages-cachyos-rc-lto.zfs_cachyos;
-          };
-      in
       rec {
         systems = [ "x86_64-linux" ];
 
@@ -77,7 +47,7 @@
           }:
           rec {
             # Legacy packages contain linux-cachyos-* and linuxPackages-cachyos-*
-            legacyPackages = loadPackages pkgs;
+            legacyPackages = import ./loadPackages.nix inputs pkgs;
 
             # Packages only contain linux-cachyos-* due to Flake schema requirements
             packages = lib.filterAttrs (_: lib.isDerivation) legacyPackages;

--- a/loadPackages.nix
+++ b/loadPackages.nix
@@ -1,0 +1,28 @@
+inputs:
+pkgs:
+let
+  load =
+    path:
+    pkgs.lib.removeAttrs
+      (pkgs.callPackage path {
+        inherit inputs;
+      })
+      [
+        "override"
+        "overrideDerivation"
+      ];
+  kernels = load ./kernel-cachyos;
+  packages = load ./kernel-cachyos/packages.nix;
+in
+kernels
+// packages
+// {
+  zfs-cachyos = packages.linuxPackages-cachyos-latest.zfs_cachyos;
+  zfs-cachyos-lto = packages.linuxPackages-cachyos-latest-lto.zfs_cachyos;
+  zfs-cachyos-lts = packages.linuxPackages-cachyos-lts.zfs_cachyos;
+  zfs-cachyos-lts-lto = packages.linuxPackages-cachyos-lts-lto.zfs_cachyos;
+  zfs-cachyos-hardened = packages.linuxPackages-cachyos-hardened.zfs_cachyos;
+  zfs-cachyos-hardened-lto = packages.linuxPackages-cachyos-hardened-lto.zfs_cachyos;
+  zfs-cachyos-rc = packages.linuxPackages-cachyos-rc.zfs_cachyos;
+  zfs-cachyos-rc-lto = packages.linuxPackages-cachyos-rc-lto.zfs_cachyos;
+}


### PR DESCRIPTION
This will allow me to import this file directly, without reimporting `pkgs`. This saves on eval time, since if the user has their own instance of pkgs with allowUnfree set to true, it prevents it from being reimported. For non "power users", this makes no difference.