### PR TITLE
Fix broken ZFS brokenness check

### DIFF
--- a/kernel-cachyos/mkCachyKernel.nix
+++ b/kernel-cachyos/mkCachyKernel.nix
@@ -201,7 +201,7 @@ lib.makeOverridable (
           "Linux CachyOS Kernel"
           + lib.optionalString (lto == "thin") " with Clang+ThinLTO"
           + lib.optionalString (lto == "full") " with Clang+FullLTO";
-        broken = !stdenv.isx86_64;
+        broken = !stdenv.hostPlatform.isx86_64;
       }
       // (args.extraMeta or { });
 


### PR DESCRIPTION
zfs build on release is failing when building using nixos-unstable 0e251e24a4f24e036a084b6b4b2d2491af4167f4.
This fixes evaluation.

Not sure exactly the commit that broke things, but this should be the more idiomatic reference path anyways.