### PR TITLE
Update deprecated code

### DIFF
--- a/kernel-cachyos/mkCachyKernel.nix
+++ b/kernel-cachyos/mkCachyKernel.nix
@@ -201,7 +201,7 @@ lib.makeOverridable (
           "Linux CachyOS Kernel"
           + lib.optionalString (lto == "thin") " with Clang+ThinLTO"
           + lib.optionalString (lto == "full") " with Clang+FullLTO";
-        broken = !stdenv.isx86_64;
+        broken = !stdenv.hostPlatform.isx86_64;
       }
       // (args.extraMeta or { });
 


### PR DESCRIPTION
Fixes the below warning when building the system:
`evaluation warning: stdenv.isx86_64 is deprecated, use stdenv.hostPlatform.isx86_64 instead`